### PR TITLE
Add json pretty print command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bezzabot"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 keywords = ["teloxide", "telegram", "telegram-bot", "bot", "raspberry pi", "educational", "pet-project"]
 categories = ["web-programming", "asynchronous"]
@@ -23,3 +23,4 @@ openssl = { version = "0.10.45", default-features = false, features = ["vendored
 openssl-probe = "0.1.5"
 rand = "0.8.5"
 base64 = "0.21.0"
+serde_json = { version = "1.0.94", features = ["preserve_order"] }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -31,7 +31,17 @@ use crate::command::switch_keyboard::{FromLanguage, Layout, ToLanguage};
 use radix::radix_parser;
 use switch_keyboard::skb_parser;
 use teloxide::utils::command::BotCommands;
+use teloxide::RequestError;
 use winner::winner_parser;
+
+pub struct BotError;
+
+impl BotError {
+    pub fn invalid_json(source: serde_json::Error, raw_json: &str) -> RequestError {
+        let raw = Box::from(raw_json);
+        RequestError::InvalidJson { source, raw }
+    }
+}
 
 #[derive(BotCommands, Debug, Clone)]
 #[command(rename_rule = "lowercase", description = "Доступные команды:")]
@@ -62,15 +72,14 @@ pub enum BotCommand {
     #[command(description = "URL safe base64 decoder. /b64d string")]
     B64D(String),
 
+    #[command(description = "Json pretty print. /jp json_string")]
+    Jp(String),
+
     #[command(
         parse_with = radix_parser,
         description = "Radix converter. /radix 2 16 1111"
     )]
     Radix(FromRadix, ToRadix, String),
-    // JsonPretty { ::serde_json::to_string_pretty(&obj)
-    //     value: String
-    // },
-    // Jwt { value: String },
     // #[command(description = "Запрос в wikipedia. Пример: /wikit простое число.")]
     // Wikit { query: String },
 }


### PR DESCRIPTION
Добавил команду jp. Выполняет pretty print json строки. В случае ошибки пока ничего не возвращает. В планах вернуть текст ошибки с описанием деталей. На каком символе ошибка и т.д.

Пример.
input:
/jp {"a": 123, "b": [1,2,3], "c" : {"d": "inner"} } output:
{
  "a": 123,
  "b": [
    1,
    2,
    3
  ],
  "c": {
    "d": "inner"
  }
}

https://github.com/radiopapus/bezzabot/issues/6