### PR TITLE
feat(2 new commands encode and decode)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bezzabot"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 keywords = ["teloxide", "telegram", "telegram-bot", "bot", "raspberry pi", "educational", "pet-project"]
 categories = ["web-programming", "asynchronous"]
@@ -25,3 +25,4 @@ rand = "0.8.5"
 base64 = "0.21.0"
 serde_json = { version = "1.0.94", features = ["preserve_order"] }
 qrcode-generator = "4.1.7"
+url = "2.4.0"

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ curl -X POST https://api.telegram.org/bot{TOKEN_FROM_TELEGRAM}/setWebhook?url={N
 
 ```/winner``` — Выбирает случайный id из списка. Пример: /winner 1 2 3 4 5
 
-```/b64e``` — URL safe base64 encoder. /b64e string
+```/encode -f {b64, url} text``` — Кодирует строку в заданном формате. base84, urlencode. 
 
-```/b64d``` — URL safe base64 decoder. /b64d string
+```/decode -f {b64, url} text``` — Декодирует строку в заданном формате. base84, urlencode.
 
 ```/jp``` — Json pretty print. /jp json_string
 

--- a/src/command/encdec.rs
+++ b/src/command/encdec.rs
@@ -1,0 +1,55 @@
+/*
+ * ______          _ _
+ * | ___ \        | (_)
+ * | |_/ /__ _  __| |_  ___  _ __   __ _ _ __  _   _ ___
+ * |    // _` |/ _` | |/ _ \| '_ \ / _` | '_ \| | | / __|
+ * | |\ \ (_| | (_| | | (_) | |_) | (_| | |_) | |_| \__ \
+ * \_| \_\__,_|\__,_|_|\___/| .__/ \__,_| .__/ \__,_|___/
+ *                          | |         | |
+ *                          |_|         |_|
+ *
+ * twitch: twitch.tv/radiopapus
+ * github: https://github.com/radiopapus
+ * telegram: https://t.me/radiopapus
+ *
+ * Отказ от ответственности - Использовать только в образовательных целях. Распространяется "как есть".
+ *
+ * Disclaimer - Only for educational purposes.
+ *
+ * 2023.
+ *
+ *
+ */
+
+use crate::command::encdec::EncDecFormat::{Url, B64};
+use teloxide::utils::command::ParseError;
+
+#[derive(Clone, Debug)]
+pub enum EncDecFormat {
+    B64,
+    Url,
+}
+
+pub fn encdec_parser(input: String) -> Result<(String, EncDecFormat), ParseError> {
+    let args: Vec<&str> = input.split_whitespace().collect();
+
+    if args.len() <= 2 {
+        return Err(ParseError::IncorrectFormat(
+            "Should be /enc -f {format} string. f.i.  /enc -f b64 text".into(),
+        ));
+    }
+
+    let format = match args[1] {
+        "b64" => B64,
+        "url" => Url,
+        _ => {
+            return Err(ParseError::IncorrectFormat(
+                "Available formats are b64, url.".into(),
+            ))
+        }
+    };
+
+    let string: Vec<String> = args[2..].iter().map(|c| c.to_string()).collect();
+
+    Ok((string.join(" "), format))
+}

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -22,26 +22,19 @@
  */
 
 pub mod datetime_from_unix;
+pub mod encdec;
 pub mod radix;
 pub mod switch_keyboard;
 pub mod winner;
 
+use crate::command::encdec::EncDecFormat;
 use crate::command::radix::{FromRadix, ToRadix};
 use crate::command::switch_keyboard::{FromLanguage, Layout, ToLanguage};
+use encdec::encdec_parser;
 use radix::radix_parser;
 use switch_keyboard::skb_parser;
 use teloxide::utils::command::BotCommands;
-use teloxide::RequestError;
 use winner::winner_parser;
-
-pub struct BotError;
-
-impl BotError {
-    pub fn invalid_json(source: serde_json::Error, raw_json: &str) -> RequestError {
-        let raw = Box::from(raw_json);
-        RequestError::InvalidJson { source, raw }
-    }
-}
 
 #[derive(BotCommands, Debug, Clone)]
 #[command(rename_rule = "lowercase", description = "Доступные команды:")]
@@ -69,11 +62,17 @@ pub enum BotCommand {
     )]
     Winner(String),
 
-    #[command(description = "URL safe base64 encoder. /b64e string")]
-    B64E(String),
+    #[command(
+        parse_with = encdec_parser,
+        description = r#"Кодирует текст по заданному формату . /enc -f b64 text. Доступные форматы b64, url."#
+    )]
+    Encode(String, EncDecFormat),
 
-    #[command(description = "URL safe base64 decoder. /b64d string")]
-    B64D(String),
+    #[command(
+        parse_with = encdec_parser,
+        description = r#"Декодирует текст по заданному формату . /dec -f b64 text. Доступные форматы b64, url."#
+    )]
+    Decode(String, EncDecFormat),
 
     #[command(description = "Json pretty print. /jp json_string")]
     Jp(String),


### PR DESCRIPTION
https://github.com/radiopapus/bezzabot/issues/12.
Теперь одна команда encode с указанием формата. Например /encode -f b64 текст закодирует строку в формате base64. Также добавил формат для urlencode.
Также возвращаем ошибки с описанием, раньше молчали. Добавлена зависимость url для поддержки urlencode. Также исправил команду Jp- тоже возвращает текстовое описание ошибки.